### PR TITLE
Version 7.1.2.post1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ravendb~=7.1.2
-ravendb-embedded==7.1.2
+ravendb-embedded==7.1.2.post1
 setuptools~=68.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="ravendb-test-driver",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.1.2",
+    version="7.1.2.post1",
     description="RavenDB package for writing integration tests against RavenDB server",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
@@ -14,5 +14,5 @@ setup(
     keywords=["ravendb", "nosql", "database", "test", "driver"],
     python_requires="~=3.9",
     license_files="LICENSE",
-    install_requires=["ravendb-embedded==7.1.2", "ravendb~=7.1.2"],
+    install_requires=["ravendb-embedded==7.1.2.post1", "ravendb~=7.1.2"],
 )


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-953

```
WARNING: The candidate selected for download or install is a yanked version: 'ravendb' candidate (version 7.1.2 at https://files.pythonhosted.org/packages/8b/d3/16e2d3db1d96b6c15d181881085a54fc2a79bb9afeff2147420bab562cea/ravendb-7.1.2-py3-none-any.whl (from https://pypi.org/simple/ravendb/) (requires-python:~=3.9))
Reason for being yanked: This release is corrupted - it lacks Ai Agents `operations` library, which is exposed at the top-level of the library -> `import ravendb` causes error
```