### PR TITLE
Release 7.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ravendb~=7.2.1
-ravendb-embedded==7.2.1
+ravendb~=7.2.2
+ravendb-embedded==7.2.2
 setuptools~=68.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="ravendb-test-driver",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.2.1",
+    version="7.2.2",
     description="RavenDB package for writing integration tests against RavenDB server",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
@@ -14,5 +14,5 @@ setup(
     keywords=["ravendb", "nosql", "database", "test", "driver"],
     python_requires="~=3.9",
     license_files="LICENSE",
-    install_requires=["ravendb-embedded==7.2.1", "ravendb~=7.2.1"],
+    install_requires=["ravendb-embedded==7.2.2", "ravendb~=7.2.2"],
 )


### PR DESCRIPTION
Release **ravendb-test-driver 7.2.2**.

Bumps `7.2.1 -> 7.2.2` in `setup.py` (`version`, `ravendb-embedded==` and `ravendb~=` pins) and `requirements.txt`. `setuptools` left as-is.

No functional changes since 7.2.1 — this tracks the embedded 7.2.2 release (the `ravendb-embedded` pin moves to `==7.2.2`).

> Depends on **ravendb-embedded 7.2.2** being on PyPI first. Merge/publish embedded #31 before this one.

Once merged, the package will be built and published to PyPI manually (twine).
