### PR TITLE
Release 7.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ravendb~=7.2.2
-ravendb-embedded==7.2.2
+ravendb~=7.2.3
+ravendb-embedded==7.2.3
 setuptools~=68.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="ravendb-test-driver",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.2.2",
+    version="7.2.3",
     description="RavenDB package for writing integration tests against RavenDB server",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
@@ -14,5 +14,5 @@ setup(
     keywords=["ravendb", "nosql", "database", "test", "driver"],
     python_requires="~=3.9",
     license_files="LICENSE",
-    install_requires=["ravendb-embedded==7.2.2", "ravendb~=7.2.2"],
+    install_requires=["ravendb-embedded==7.2.3", "ravendb~=7.2.3"],
 )


### PR DESCRIPTION
Release **ravendb-test-driver 7.2.3** — tracks the 7.2.3 line.

Bumps `7.2.2 -> 7.2.3` in `setup.py` (`version`, `ravendb-embedded==` and `ravendb~=` pins) and `requirements.txt`. `setuptools` unchanged.

> Depends on **ravendb-embedded 7.2.3** being on PyPI first (#32). Publish embedded before this one.

Once merged, built and published to PyPI manually (twine).
